### PR TITLE
genallipc.py fixes

### DIFF
--- a/docs/ifaces.html
+++ b/docs/ifaces.html
@@ -2189,7 +2189,7 @@
 					<li class="list-group-item">
 						<h3>Provides:</h3>
 						<ul>
-							<li>audrec:u</li>
+							<li>audren:u</li>
 						</ul>
 					</li>
 					<li class="list-group-item">
@@ -2293,7 +2293,7 @@
 					<li class="list-group-item">
 						<h3>Provides:</h3>
 						<ul>
-							<li>audren:u</li>
+							<li>audrec:u</li>
 						</ul>
 					</li>
 					<li class="list-group-item">
@@ -3081,6 +3081,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="39" aria-valuemin="0" aria-valuemax="100" style="width: 39%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>cec-mgr</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::cec::ICecManager(0)">Unknown0()</li>
@@ -3285,6 +3291,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100" style="width: 33%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>ethc:c</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::eth::sf::IEthInterface(0)">Unknown0()</li>
@@ -3309,7 +3321,6 @@
 					<li class="list-group-item">
 						<h3>Provides:</h3>
 						<ul>
-							<li>ethc:c</li>
 							<li>ethc:i</li>
 						</ul>
 					</li>
@@ -3960,6 +3971,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>fsp-ldr</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::fssrv::sf::IFileSystemProxyForLoader(0)">MountCode(<a href="types.html#nn::ApplicationId">nn::ApplicationId</a> TID, buffer&lt;i8, 0x19, 0x301&gt; contentPath) -&gt; object&lt;<a href="ifaces.html#nn::fssrv::sf::IFileSystem">nn::fssrv::sf::IFileSystem</a>&gt; contentFs</li>
@@ -3976,6 +3993,12 @@
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>fsp-pr</li>
+						</ul>
 					</li>
 					<li class="list-group-item">
 						<h3>Commands:</h3>
@@ -4843,6 +4866,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>ldr:shel</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::ldr::detail::IShellInterface(0)">Unknown0()</li>
@@ -4901,11 +4930,62 @@
 			<br />
 			<div class="card">
 				<div class="card-header">
+					<a href="#nn::lr::IAddOnContentLocationResolver"><h2 id="nn::lr::IAddOnContentLocationResolver">nn::lr::IAddOnContentLocationResolver</h2></a>
+				</div>
+				<ul class="list-group list-group-flush">
+					<li class="list-group-item">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="41" aria-valuemin="0" aria-valuemax="100" style="width: 41%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Commands:</h3>
+						<ol>
+							<li value="0" id="nn::lr::IAddOnContentLocationResolver(0)">Unknown0()</li>
+							<li value="1" id="nn::lr::IAddOnContentLocationResolver(1)">Unknown1(u8, u64)</li>
+							<li value="2" id="nn::lr::IAddOnContentLocationResolver(2)">Unknown2()</li>
+						</ol>
+					</li>
+				</ul>
+			</div>
+			<br />
+			<div class="card">
+				<div class="card-header">
+					<a href="#nn::lr::ILocationResolver"><h2 id="nn::lr::ILocationResolver">nn::lr::ILocationResolver</h2></a>
+				</div>
+				<ul class="list-group list-group-flush">
+					<li class="list-group-item">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Commands:</h3>
+						<ol>
+							<li value="0" id="nn::lr::ILocationResolver(0)">Unknown0()</li>
+							<li value="1" id="nn::lr::ILocationResolver(1)">Unknown1()</li>
+							<li value="2" id="nn::lr::ILocationResolver(2)">Unknown2()</li>
+							<li value="3" id="nn::lr::ILocationResolver(3)">Unknown3()</li>
+							<li value="4" id="nn::lr::ILocationResolver(4)">Unknown4()</li>
+							<li value="5" id="nn::lr::ILocationResolver(5)">Unknown5()</li>
+							<li value="6" id="nn::lr::ILocationResolver(6)">Unknown6()</li>
+							<li value="7" id="nn::lr::ILocationResolver(7)">Unknown7()</li>
+							<li value="8" id="nn::lr::ILocationResolver(8)">Unknown8()</li>
+							<li value="9" id="nn::lr::ILocationResolver(9)">Unknown9()</li>
+						</ol>
+					</li>
+				</ul>
+			</div>
+			<br />
+			<div class="card">
+				<div class="card-header">
 					<a href="#nn::lr::ILocationResolverManager"><h2 id="nn::lr::ILocationResolverManager">nn::lr::ILocationResolverManager</h2></a>
 				</div>
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="31" aria-valuemin="0" aria-valuemax="100" style="width: 31%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>lr</li>
+						</ul>
 					</li>
 					<li class="list-group-item">
 						<h3>Commands:</h3>
@@ -4921,33 +5001,7 @@
 			<br />
 			<div class="card">
 				<div class="card-header">
-					<a href="#nn::lr::ILocationResolverManager_0"><h2 id="nn::lr::ILocationResolverManager_0">nn::lr::ILocationResolverManager_0</h2></a>
-				</div>
-				<ul class="list-group list-group-flush">
-					<li class="list-group-item">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
-					</li>
-					<li class="list-group-item">
-						<h3>Commands:</h3>
-						<ol>
-							<li value="0" id="nn::lr::ILocationResolverManager_0(0)">Unknown0()</li>
-							<li value="1" id="nn::lr::ILocationResolverManager_0(1)">Unknown1()</li>
-							<li value="2" id="nn::lr::ILocationResolverManager_0(2)">Unknown2()</li>
-							<li value="3" id="nn::lr::ILocationResolverManager_0(3)">Unknown3()</li>
-							<li value="4" id="nn::lr::ILocationResolverManager_0(4)">Unknown4()</li>
-							<li value="5" id="nn::lr::ILocationResolverManager_0(5)">Unknown5()</li>
-							<li value="6" id="nn::lr::ILocationResolverManager_0(6)">Unknown6()</li>
-							<li value="7" id="nn::lr::ILocationResolverManager_0(7)">Unknown7()</li>
-							<li value="8" id="nn::lr::ILocationResolverManager_0(8)">Unknown8()</li>
-							<li value="9" id="nn::lr::ILocationResolverManager_0(9)">Unknown9()</li>
-						</ol>
-					</li>
-				</ul>
-			</div>
-			<br />
-			<div class="card">
-				<div class="card-header">
-					<a href="#nn::lr::ILocationResolverManager_1"><h2 id="nn::lr::ILocationResolverManager_1">nn::lr::ILocationResolverManager_1</h2></a>
+					<a href="#nn::lr::IRegisteredLocationResolver"><h2 id="nn::lr::IRegisteredLocationResolver">nn::lr::IRegisteredLocationResolver</h2></a>
 				</div>
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
@@ -4956,33 +5010,14 @@
 					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
-							<li value="0" id="nn::lr::ILocationResolverManager_1(0)">Unknown0()</li>
-							<li value="1" id="nn::lr::ILocationResolverManager_1(1)">Unknown1()</li>
-							<li value="2" id="nn::lr::ILocationResolverManager_1(2)">Unknown2(u64)</li>
-							<li value="3" id="nn::lr::ILocationResolverManager_1(3)">Unknown3()</li>
-							<li value="4" id="nn::lr::ILocationResolverManager_1(4)">Unknown4()</li>
-							<li value="5" id="nn::lr::ILocationResolverManager_1(5)">Unknown5()</li>
-							<li value="6" id="nn::lr::ILocationResolverManager_1(6)">Unknown6(u64)</li>
-							<li value="7" id="nn::lr::ILocationResolverManager_1(7)">Unknown7()</li>
-						</ol>
-					</li>
-				</ul>
-			</div>
-			<br />
-			<div class="card">
-				<div class="card-header">
-					<a href="#nn::lr::ILocationResolverManager_3"><h2 id="nn::lr::ILocationResolverManager_3">nn::lr::ILocationResolverManager_3</h2></a>
-				</div>
-				<ul class="list-group list-group-flush">
-					<li class="list-group-item">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="41" aria-valuemin="0" aria-valuemax="100" style="width: 41%"></div></div>
-					</li>
-					<li class="list-group-item">
-						<h3>Commands:</h3>
-						<ol>
-							<li value="0" id="nn::lr::ILocationResolverManager_3(0)">Unknown0()</li>
-							<li value="1" id="nn::lr::ILocationResolverManager_3(1)">Unknown1(u8, u64)</li>
-							<li value="2" id="nn::lr::ILocationResolverManager_3(2)">Unknown2()</li>
+							<li value="0" id="nn::lr::IRegisteredLocationResolver(0)">Unknown0()</li>
+							<li value="1" id="nn::lr::IRegisteredLocationResolver(1)">Unknown1()</li>
+							<li value="2" id="nn::lr::IRegisteredLocationResolver(2)">Unknown2(u64)</li>
+							<li value="3" id="nn::lr::IRegisteredLocationResolver(3)">Unknown3()</li>
+							<li value="4" id="nn::lr::IRegisteredLocationResolver(4)">Unknown4()</li>
+							<li value="5" id="nn::lr::IRegisteredLocationResolver(5)">Unknown5()</li>
+							<li value="6" id="nn::lr::IRegisteredLocationResolver(6)">Unknown6(u64)</li>
+							<li value="7" id="nn::lr::IRegisteredLocationResolver(7)">Unknown7()</li>
 						</ol>
 					</li>
 				</ul>
@@ -5093,6 +5128,12 @@
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" style="width: 65%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>ncm</li>
+						</ul>
 					</li>
 					<li class="list-group-item">
 						<h3>Commands:</h3>
@@ -7415,6 +7456,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>pm:info</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::pm::detail::IInformationInterface(0)">Unknown0(u64) -&gt; u64</li>
@@ -8058,6 +8105,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>sm:m</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::sm::detail::IManagerInterface(0)">Unknown0(u64, buffer&lt;unknown, 5, 0&gt;, buffer&lt;unknown, 5, 0&gt;)</li>
@@ -8074,6 +8127,12 @@
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>sm:</li>
+						</ul>
 					</li>
 					<li class="list-group-item">
 						<h3>Commands:</h3>
@@ -8182,6 +8241,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="35" aria-valuemin="0" aria-valuemax="100" style="width: 35%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>spl:</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Commands:</h3>
 						<ol>
 							<li value="0" id="nn::spl::detail::IGeneralInterface(0)">Unknown0(u32) -&gt; u64</li>
@@ -8220,6 +8285,12 @@
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
+					</li>
+					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>csrng</li>
+						</ul>
 					</li>
 					<li class="list-group-item">
 						<h3>Commands:</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IFinalOutputRecorderManagerForDebugger">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 						audrec:d</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IAudioRendererManager">
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IFinalOutputRecorderManager">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="37" aria-valuemin="0" aria-valuemax="100" style="width: 37%"></div></div>
 						audrec:u</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IAudioRendererManagerForApplet">
@@ -98,7 +98,7 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IAudioRendererManagerForDebugger">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 						audren:d</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IFinalOutputRecorderManager">
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::audio::detail::IAudioRendererManager">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="37" aria-valuemin="0" aria-valuemax="100" style="width: 37%"></div></div>
 						audren:u</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::bcat::detail::ipc::IServiceCreator">
@@ -161,6 +161,12 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::capsrv::sf::IScreenShotApplicationService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 						caps:su</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::cec::ICecManager">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="39" aria-valuemin="0" aria-valuemax="100" style="width: 39%"></div></div>
+						cec-mgr</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::spl::detail::IRandomInterface">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
+						csrng</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::erpt::sf::IContext">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
 						erpt:c</a>
@@ -170,8 +176,8 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::es::IETicketService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="44" aria-valuemin="0" aria-valuemax="100" style="width: 44%"></div></div>
 						es</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::eth::sf::IEthInterfaceGroup">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%"></div></div>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::eth::sf::IEthInterface">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100" style="width: 33%"></div></div>
 						ethc:c</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::eth::sf::IEthInterfaceGroup">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%"></div></div>
@@ -215,6 +221,12 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::friends::detail::ipc::IServiceCreator">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 						friend:v</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::fssrv::sf::IFileSystemProxyForLoader">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
+						fsp-ldr</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::fssrv::sf::IProgramRegistry">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
+						fsp-pr</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::fssrv::sf::IFileSystemProxy">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="81" aria-valuemin="0" aria-valuemax="100" style="width: 81%"></div></div>
 						fsp-srv</a>
@@ -272,8 +284,8 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lm::ILogService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="87" aria-valuemin="0" aria-valuemax="100" style="width: 87%"></div></div>
 						lm</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::ncm::detail::LocationResolverInterface">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div></div>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolverManager">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="31" aria-valuemin="0" aria-valuemax="100" style="width: 31%"></div></div>
 						lr</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::mii::detail::IStaticService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
@@ -446,6 +458,9 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::pm::detail::IBootModeInterface">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 						pm:bm</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::pm::detail::IInformationInterface">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
+						pm:info</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::pm::detail::IShellInterface">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 						pm:shell</a>
@@ -497,6 +512,12 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#SmService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 						sm:</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::sm::detail::IManagerInterface">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
+						sm:m</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::spl::detail::IGeneralInterface">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="35" aria-valuemin="0" aria-valuemax="100" style="width: 35%"></div></div>
+						spl:</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::spsm::detail::IPowerStateInterface">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="62" aria-valuemin="0" aria-valuemax="100" style="width: 62%"></div></div>
 						spsm</a>
@@ -1041,18 +1062,18 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lm::ILogger">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%"></div></div>
 						nn::lm::ILogger</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::IAddOnContentLocationResolver">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="41" aria-valuemin="0" aria-valuemax="100" style="width: 41%"></div></div>
+						nn::lr::IAddOnContentLocationResolver</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolver">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
+						nn::lr::ILocationResolver</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolverManager">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="62" aria-valuemin="0" aria-valuemax="100" style="width: 62%"></div></div>
 						nn::lr::ILocationResolverManager</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolverManager_0">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100" style="width: 25%"></div></div>
-						nn::lr::ILocationResolverManager_0</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolverManager_1">
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::IRegisteredLocationResolver">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="37" aria-valuemin="0" aria-valuemax="100" style="width: 37%"></div></div>
-						nn::lr::ILocationResolverManager_1</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::lr::ILocationResolverManager_3">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="41" aria-valuemin="0" aria-valuemax="100" style="width: 41%"></div></div>
-						nn::lr::ILocationResolverManager_3</a>
+						nn::lr::IRegisteredLocationResolver</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::mii::detail::IDatabaseService">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div></div>
 						nn::mii::detail::IDatabaseService</a>

--- a/ipcdefs/auto.id
+++ b/ipcdefs/auto.id
@@ -1019,7 +1019,7 @@ interface nn::audio::detail::IAudioRenderer {
 	[11] Unknown11();
 }
 
-interface nn::audio::detail::IAudioRendererManager is audrec:u {
+interface nn::audio::detail::IAudioRendererManager is audren:u {
 	[0] Unknown0(bytes<0x34>, u64, u64, pid, KObject, KObject) -> object<IUnknown>;
 	[1] Unknown1(bytes<0x34>) -> u64;
 	[2] Unknown2(u64) -> object<IUnknown>;
@@ -1053,7 +1053,7 @@ interface nn::audio::detail::IFinalOutputRecorder {
 	[9] Unknown9() -> (u32, u64, buffer<unknown, 0x22, 0>);
 }
 
-interface nn::audio::detail::IFinalOutputRecorderManager is audren:u {
+interface nn::audio::detail::IFinalOutputRecorderManager is audrec:u {
 	[0] Unknown0(u64, u64, KObject) -> (u128, object<IUnknown>);
 }
 
@@ -1369,7 +1369,7 @@ interface nn::capsrv::sf::IScreenShotService is caps:ss {
 	[204] Unknown204();
 }
 
-interface nn::cec::ICecManager {
+interface nn::cec::ICecManager is cec-mgr {
 	[0] Unknown0();
 	[1] Unknown1(u32) -> u32;
 	[2] Unknown2(u32);
@@ -1445,7 +1445,7 @@ interface nn::es::IETicketService is es {
 	[21] Unknown21();
 }
 
-interface nn::eth::sf::IEthInterface {
+interface nn::eth::sf::IEthInterface is ethc:c {
 	[0] Unknown0();
 	[1] Unknown1();
 	[2] Unknown2();
@@ -1454,7 +1454,7 @@ interface nn::eth::sf::IEthInterface {
 	[5] Unknown5();
 }
 
-interface nn::eth::sf::IEthInterfaceGroup is ethc:c, ethc:i {
+interface nn::eth::sf::IEthInterfaceGroup is ethc:i {
 	[0] Unknown0() -> KObject;
 	[1] Unknown1();
 	[2] Unknown2();
@@ -1674,7 +1674,7 @@ interface nn::fssrv::sf::IFileSystem {
 	[14] Unknown14(buffer<unknown, 0x19, 0x301>) -> bytes<0x20>;
 }
 
-interface nn::fssrv::sf::IFileSystemProxy {
+interface nn::fssrv::sf::IFileSystemProxy is fsp-srv {
 	[1] Unknown1(u64, pid);
 	[2] Unknown2() -> object<IUnknown>;
 	[7] Unknown7(u32, u64) -> object<IUnknown>;
@@ -1736,12 +1736,12 @@ interface nn::fssrv::sf::IFileSystemProxy {
 	[1006] Unknown1006(buffer<unknown, 5, 0>);
 }
 
-interface nn::fssrv::sf::IFileSystemProxyForLoader {
+interface nn::fssrv::sf::IFileSystemProxyForLoader is fsp-ldr {
 	[0] Unknown0(u64, buffer<unknown, 0x19, 0x301>) -> object<IUnknown>;
 	[1] Unknown1(u64) -> u8;
 }
 
-interface nn::fssrv::sf::IProgramRegistry {
+interface nn::fssrv::sf::IProgramRegistry is fsp-pr {
 	[0] Unknown0(u8, u64, u64, u64, u64, buffer<unknown, 5, 0>, buffer<unknown, 5, 0>);
 	[1] Unknown1(u64);
 	[256] Unknown256(u8);
@@ -2167,7 +2167,7 @@ interface nn::ldn::detail::IUserServiceCreator is ldn:u {
 	[0] Unknown0() -> object<IUnknown>;
 }
 
-interface nn::ldr::detail::IShellInterface {
+interface nn::ldr::detail::IShellInterface is ldr:shel {
 	[0] Unknown0();
 	[1] Unknown1();
 }
@@ -2181,14 +2181,13 @@ interface nn::lm::ILogger {
 	[1] Unknown1(u32);
 }
 
-interface nn::lr::ILocationResolverManager {
+interface nn::lr::IAddOnContentLocationResolver {
 	[0] Unknown0();
-	[1] Unknown1() -> object<IUnknown>;
-	[2] Unknown2(u8);
-	[3] Unknown3() -> object<IUnknown>;
+	[1] Unknown1(u8, u64);
+	[2] Unknown2();
 }
 
-interface nn::lr::ILocationResolverManager_0 {
+interface nn::lr::ILocationResolver {
 	[0] Unknown0();
 	[1] Unknown1();
 	[2] Unknown2();
@@ -2201,7 +2200,14 @@ interface nn::lr::ILocationResolverManager_0 {
 	[9] Unknown9();
 }
 
-interface nn::lr::ILocationResolverManager_1 {
+interface nn::lr::ILocationResolverManager is lr {
+	[0] Unknown0();
+	[1] Unknown1() -> object<IUnknown>;
+	[2] Unknown2(u8);
+	[3] Unknown3() -> object<IUnknown>;
+}
+
+interface nn::lr::IRegisteredLocationResolver {
 	[0] Unknown0();
 	[1] Unknown1();
 	[2] Unknown2(u64);
@@ -2210,12 +2216,6 @@ interface nn::lr::ILocationResolverManager_1 {
 	[5] Unknown5();
 	[6] Unknown6(u64);
 	[7] Unknown7();
-}
-
-interface nn::lr::ILocationResolverManager_3 {
-	[0] Unknown0();
-	[1] Unknown1(u8, u64);
-	[2] Unknown2();
 }
 
 interface nn::mii::detail::IDatabaseService {
@@ -2258,7 +2258,7 @@ interface nn::mmnv::IRequest is mm:u {
 	[7] Unknown7(u32) -> u32;
 }
 
-interface nn::ncm::IContentManager {
+interface nn::ncm::IContentManager is ncm {
 	[0] Unknown0(u8);
 	[1] Unknown1(u8);
 	[2] Unknown2(u8);
@@ -3300,16 +3300,16 @@ interface nn::pl::detail::ISharedFontManager is pl:u {
 	[5] Unknown5(u64) -> (u8, u32, buffer<unknown, 6, 0>, buffer<unknown, 6, 0>, buffer<unknown, 6, 0>);
 }
 
-interface nn::pm::detail::IBootModeInterface {
+interface nn::pm::detail::IBootModeInterface is pm:bm {
 	[0] Unknown0() -> u32;
 	[1] Unknown1();
 }
 
-interface nn::pm::detail::IInformationInterface {
+interface nn::pm::detail::IInformationInterface is pm:info {
 	[0] Unknown0(u64) -> u64;
 }
 
-interface nn::pm::detail::IShellInterface {
+interface nn::pm::detail::IShellInterface is pm:shel {
 	[0] Unknown0();
 	[1] Unknown1(u64);
 	[2] Unknown2(u64);
@@ -3587,12 +3587,12 @@ interface nn::settings::ISystemSettingsServer is set:sys {
 	[121] SetPushNotificationActivityModeOnSleep(i32);
 }
 
-interface nn::sm::detail::IManagerInterface {
+interface nn::sm::detail::IManagerInterface is sm:m {
 	[0] Unknown0(u64, buffer<unknown, 5, 0>, buffer<unknown, 5, 0>);
 	[1] Unknown1(u64);
 }
 
-interface nn::sm::detail::IUserInterface {
+interface nn::sm::detail::IUserInterface is sm: {
 	[0] Unknown0(u64, pid);
 	[1] Unknown1(u64) -> KObject;
 	[2] Unknown2(u64, u8, u32) -> KObject;
@@ -3646,7 +3646,7 @@ interface nn::socket::sf::IClient is bsd:u, bsd:s {
 	[30] Unknown30(u32, u32, u32, buffer<unknown, 0x21, 0>, buffer<unknown, 0x21, 0>) -> (u32, u32);
 }
 
-interface nn::spl::detail::IGeneralInterface {
+interface nn::spl::detail::IGeneralInterface is spl: {
 	[0] Unknown0(u32) -> u64;
 	[1] Unknown1();
 	[2] Unknown2();
@@ -3673,7 +3673,7 @@ interface nn::spl::detail::IGeneralInterface {
 	[25] Unknown25();
 }
 
-interface nn::spl::detail::IRandomInterface {
+interface nn::spl::detail::IRandomInterface is csrng {
 	[0] Unknown0() -> buffer<unknown, 6, 0>;
 }
 

--- a/scripts/genallipc.py
+++ b/scripts/genallipc.py
@@ -6945,27 +6945,27 @@ clientInfo = (
 	('nn::lr::ILocationResolverManager', 1, '0 bytes in - 0 bytes out - OutObject<0,0>'),
 	('nn::lr::ILocationResolverManager', 2, '1 bytes in - 0 bytes out - InRaw<1,1,0>'),
 	('nn::lr::ILocationResolverManager', 3, '0 bytes in - 0 bytes out - OutObject<0,0>'),
-	('nn::lr::ILocationResolverManager_0', 0, ''),
-	('nn::lr::ILocationResolverManager_0', 1, ''),
-	('nn::lr::ILocationResolverManager_0', 2, ''),
-	('nn::lr::ILocationResolverManager_0', 3, ''),
-	('nn::lr::ILocationResolverManager_0', 4, ''),
-	('nn::lr::ILocationResolverManager_0', 5, ''),
-	('nn::lr::ILocationResolverManager_0', 6, ''),
-	('nn::lr::ILocationResolverManager_0', 7, ''),
-	('nn::lr::ILocationResolverManager_0', 8, ''),
-	('nn::lr::ILocationResolverManager_0', 9, '0 bytes in - 0 bytes out'),
-	('nn::lr::ILocationResolverManager_1', 0, ''),
-	('nn::lr::ILocationResolverManager_1', 1, ''),
-	('nn::lr::ILocationResolverManager_1', 2, '8 bytes in - 0 bytes out - InRaw<8,8,0>'),
-	('nn::lr::ILocationResolverManager_1', 3, ''),
-	('nn::lr::ILocationResolverManager_1', 4, ''),
-	('nn::lr::ILocationResolverManager_1', 5, ''),
-	('nn::lr::ILocationResolverManager_1', 6, '8 bytes in - 0 bytes out - InRaw<8,8,0>'),
-	('nn::lr::ILocationResolverManager_1', 7, ''),
-	('nn::lr::ILocationResolverManager_3', 0, ''),
-	('nn::lr::ILocationResolverManager_3', 1, '0x10 bytes in - 0 bytes out - InRaw<8,8,8>, InRaw<1,1,0>'),
-	('nn::lr::ILocationResolverManager_3', 2, '0 bytes in - 0 bytes out'),
+	('nn::lr::ILocationResolver', 0, ''),
+	('nn::lr::ILocationResolver', 1, ''),
+	('nn::lr::ILocationResolver', 2, ''),
+	('nn::lr::ILocationResolver', 3, ''),
+	('nn::lr::ILocationResolver', 4, ''),
+	('nn::lr::ILocationResolver', 5, ''),
+	('nn::lr::ILocationResolver', 6, ''),
+	('nn::lr::ILocationResolver', 7, ''),
+	('nn::lr::ILocationResolver', 8, ''),
+	('nn::lr::ILocationResolver', 9, '0 bytes in - 0 bytes out'),
+	('nn::lr::IRegisteredLocationResolver', 0, ''),
+	('nn::lr::IRegisteredLocationResolver', 1, ''),
+	('nn::lr::IRegisteredLocationResolver', 2, '8 bytes in - 0 bytes out - InRaw<8,8,0>'),
+	('nn::lr::IRegisteredLocationResolver', 3, ''),
+	('nn::lr::IRegisteredLocationResolver', 4, ''),
+	('nn::lr::IRegisteredLocationResolver', 5, ''),
+	('nn::lr::IRegisteredLocationResolver', 6, '8 bytes in - 0 bytes out - InRaw<8,8,0>'),
+	('nn::lr::IRegisteredLocationResolver', 7, ''),
+	('nn::lr::IAddOnContentLocationResolver', 0, ''),
+	('nn::lr::IAddOnContentLocationResolver', 1, '0x10 bytes in - 0 bytes out - InRaw<8,8,8>, InRaw<1,1,0>'),
+	('nn::lr::IAddOnContentLocationResolver', 2, '0 bytes in - 0 bytes out'),
 	('nn::mii::detail::IDatabaseService', 0, '4 bytes in - 1 bytes out - OutRaw<1,1,0>, InRaw<4,4,0>'),
 	('nn::mii::detail::IDatabaseService', 1, '0 bytes in - 1 bytes out - OutRaw<1,1,0>'),
 	('nn::mii::detail::IDatabaseService', 2, '4 bytes in - 4 bytes out - OutRaw<4,4,0>, InRaw<4,4,0>'),
@@ -8544,6 +8544,35 @@ clientInfo = (
 )
 
 smapping = {
+    # builtins
+    '0100000000000000': {
+        'fsp-srv': 'nn::fssrv::sf::IFileSystemProxy',
+        'fsp-ldr': 'nn::fssrv::sf::IFileSystemProxyForLoader',
+        'fsp-pr':  'nn::fssrv::sf::IProgramRegistry',
+    },
+    '0100000000000001': {
+        'ldr:shel': 'nn::ldr::detail::IShellInterface',
+        'ldr:pm':   'nn::ldr::detail::IProcessManagerInterface',
+        'ldr:dmnt': 'nn::ldr::detail::IDebugMonitorInterface',
+    },
+    '0100000000000002': {
+        'lr':  'nn::lr::ILocationResolverManager',
+        'ncm': 'nn::ncm::IContentManager',
+    },
+    '0100000000000003': {
+        'pm:info': 'nn::pm::detail::IInformationInterface',
+        'pm:shel': 'nn::pm::detail::IShellInterface',
+        'pm:bm':   'nn::pm::detail::IBootModeInterface',
+    },
+    '0100000000000004': {
+        'sm:':  'nn::sm::detail::IUserInterface',
+        'sm:m': 'nn::sm::detail::IManagerInterface',
+    },
+    '0100000000000028': {
+        'spl:':  'nn::spl::detail::IGeneralInterface',
+        'csrng': 'nn::spl::detail::IRandomInterface',
+    },
+    # not builtins
 	'0100000000000006': {  # usb
 		'usb:ds':   'nn::usb::ds::IDsService',
 		'usb:hs':   'nn::usb::hs::IClientRootSession',
@@ -8606,7 +8635,7 @@ smapping = {
 		'bsd:s':    'nn::socket::sf::IClient', # ?
 		'bsd:u':    'nn::socket::sf::IClient', # ?
 		'bsdcfg':   'nn::bsdsocket::cfg::ServerInterface',
-		'ethc:c':   'nn::eth::sf::IEthInterfaceGroup',
+		'ethc:c':   'nn::eth::sf::IEthInterface',
 		'ethc:i':   'nn::eth::sf::IEthInterfaceGroup',
 		'nsd:a':    'nn::nsd::detail::IManager', # ?
 		'nsd:u':    'nn::nsd::detail::IManager', # ?
@@ -8633,10 +8662,10 @@ smapping = {
 		'audout:u': 'nn::audio::detail::IAudioOutManager',
 		'audrec:a': 'nn::audio::detail::IFinalOutputRecorderManagerForApplet',
 		'audrec:d': 'nn::audio::detail::IFinalOutputRecorderManagerForDebugger',
-		'audrec:u': 'nn::audio::detail::IAudioRendererManager',
+		'audrec:u': 'nn::audio::detail::IFinalOutputRecorderManager',
 		'audren:a': 'nn::audio::detail::IAudioRendererManagerForApplet',
 		'audren:d': 'nn::audio::detail::IAudioRendererManagerForDebugger',
-		'audren:u': 'nn::audio::detail::IFinalOutputRecorderManager',
+		'audren:u': 'nn::audio::detail::IAudioRendererManager',
 		'hwopus':   'nn::codec::detail::IHardwareOpusDecoderManager',
 	},
 	'0100000000000015': {  # LogManager.Prod
@@ -8753,8 +8782,8 @@ smapping = {
 		'caps:sc': 'nn::capsrv::sf::IScreenShotControlService',
 		'caps:ss': 'nn::capsrv::sf::IScreenShotService',
 		'caps:su': 'nn::capsrv::sf::IScreenShotApplicationService',
-		'cec-mgr': 'nn::cec::ICecManagerx',
-		'mm:u':    'nn::mmnv::IRequest', # ?
+		'cec-mgr': 'nn::cec::ICecManager',
+		'mm:u':    'nn::mmnv::IRequest',
 		'vi:m':    'nn::visrv::sf::IManagerRootService',
 		'vi:s':    'nn::visrv::sf::ISystemRootService',
 		'vi:u':    'nn::visrv::sf::IApplicationRootService',


### PR DESCRIPTION
This resolves a few mistakes in genallipc.py

There are other issues throughout the other `.id` files where names are wrong (e.g. `SmService` vs `nn::sm::detail::IUserInterface`, `nn::ncm::IContentManager` vs `nn::ncm::detail::INcmInterface`, `nn::ro::detail::ILdrShellInterface` vs `nn::ldr::detail::IShellInterface`) not sure if it'll cause fewer problems in consumers if I try to change that or not.

This hasn't been tested with Mephisto as I don't currently have a working build environment set up, sorry.