### PR TITLE
Rerun genallipc, fix sm interface name

### DIFF
--- a/docs/ifaces.html
+++ b/docs/ifaces.html
@@ -24911,6 +24911,12 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="66" aria-valuemin="0" aria-valuemax="100" style="width: 66%"></div></div>
 					</li>
 					<li class="list-group-item">
+						<h3>Provides:</h3>
+						<ul>
+							<li>dispdrv</li>
+						</ul>
+					</li>
+					<li class="list-group-item">
 						<h3>Returned by:</h3>
 						<ul>
 							<li><a href="ifaces.html#nn::visrv::sf::IApplicationDisplayService(100)">nn::visrv::sf::IApplicationDisplayService::GetRelayService [100]</a></li>

--- a/docs/ifaces.html
+++ b/docs/ifaces.html
@@ -12,67 +12,6 @@
 			<br />
 			<div class="card">
 				<div class="card-header">
-					<a href="#SmService"><h2 id="SmService">SmService</h2></a>
-				</div>
-				<ul class="list-group list-group-flush">
-					<li class="list-group-item">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="122" aria-valuemin="0" aria-valuemax="100" style="width: 122%"></div></div>
-					</li>
-					<li class="list-group-item">
-						<h3>Provides:</h3>
-						<ul>
-							<li>sm:</li>
-						</ul>
-					</li>
-					<li class="list-group-item">
-						<h3>Commands:</h3>
-						<ol>
-							<li class="command" value="0" id="SmService(0)">
-							  <input type="checkbox" class="showDocs" id="showDocs(SmService(0))"></input>
-							  <label for="showDocs(SmService(0))" class="showDocsLabel"></label>
-							  <code class="signature">[0] <a href="#SmService(0)">Initialize</a>(pid, u64 reserved)</code>
-							  <div class="docs"><p>Needs to be called before any other command may be used. On version 3.0.0
-							and lower, if this function is not called, <code>GetService</code>, <code>RegisterService</code>
-							and <code>UnregisterService</code> may be called without restriction, thanks to
-							<code>sm:h</code>.</p>
-							<h1>Arguments</h1>
-							<ul>
-							<li><code>reserved</code>:  Should be set to 0.</li>
-							</ul>
-							</div>
-							</li>
-							<li class="command" value="1" id="SmService(1)">
-							  <input type="checkbox" class="showDocs" id="showDocs(SmService(1))"></input>
-							  <label for="showDocs(SmService(1))" class="showDocsLabel"></label>
-							  <code class="signature">[1] <a href="#SmService(1)">GetService</a>(<a href="types.html#ServiceName">ServiceName</a> name) -&gt; IPipe</code>
-							  <div class="docs"><p>Returns a handle to the given service. IPC messages may be sent to this
-							handle through <code>svcSendSyncRequest</code>.</p>
-							</div>
-							</li>
-							<li class="command" value="2" id="SmService(2)">
-							  <input type="checkbox" class="showDocs" id="showDocs(SmService(2))"></input>
-							  <label for="showDocs(SmService(2))" class="showDocsLabel"></label>
-							  <code class="signature">[2] <a href="#SmService(2)">RegisterService</a>(<a href="types.html#ServiceName">ServiceName</a> name, u8, u32 maxHandles) -&gt; NPort</code>
-							  <div class="docs"><p>Registers a service with the given name. The user can use
-							<code>svcAcceptSession</code> on the returned handle to get a new Session handle, and
-							use <code>svcReplyAndReceive</code> on those handles to reply to IPC requests.</p>
-							</div>
-							</li>
-							<li class="command" value="3" id="SmService(3)">
-							  <input type="checkbox" class="showDocs" id="showDocs(SmService(3))"></input>
-							  <label for="showDocs(SmService(3))" class="showDocsLabel"></label>
-							  <code class="signature">[3] <a href="#SmService(3)">UnregisterService</a>(<a href="types.html#ServiceName">ServiceName</a> name)</code>
-							  <div class="docs"><p>Unregisters the given service. Future <code>GetService</code> call will not return
-							this service anymore, but existing handles will stay alive.</p>
-							</div>
-							</li>
-						</ol>
-					</li>
-				</ul>
-			</div>
-			<br />
-			<div class="card">
-				<div class="card-header">
 					<a href="#nn::account::IAccountServiceForAdministrator"><h2 id="nn::account::IAccountServiceForAdministrator">nn::account::IAccountServiceForAdministrator</h2></a>
 				</div>
 				<ul class="list-group list-group-flush">
@@ -21091,7 +21030,7 @@
 				</div>
 				<ul class="list-group list-group-flush">
 					<li class="list-group-item">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="122" aria-valuemin="0" aria-valuemax="100" style="width: 122%"></div></div>
 					</li>
 					<li class="list-group-item">
 						<h3>Provides:</h3>
@@ -21103,28 +21042,43 @@
 						<h3>Commands:</h3>
 						<ol>
 							<li class="command" value="0" id="nn::sm::detail::IUserInterface(0)">
-							
-							
-							  <code class="signature">[0] <a href="#nn::sm::detail::IUserInterface(0)">Unknown0</a>(u64, pid)</code>
-							
+							  <input type="checkbox" class="showDocs" id="showDocs(nn::sm::detail::IUserInterface(0))"></input>
+							  <label for="showDocs(nn::sm::detail::IUserInterface(0))" class="showDocsLabel"></label>
+							  <code class="signature">[0] <a href="#nn::sm::detail::IUserInterface(0)">Initialize</a>(pid, u64 reserved)</code>
+							  <div class="docs"><p>Needs to be called before any other command may be used. On version 3.0.0
+							and lower, if this function is not called, <code>GetService</code>, <code>RegisterService</code>
+							and <code>UnregisterService</code> may be called without restriction, thanks to
+							<code>sm:h</code>.</p>
+							<h1>Arguments</h1>
+							<ul>
+							<li><code>reserved</code>:  Should be set to 0.</li>
+							</ul>
+							</div>
 							</li>
 							<li class="command" value="1" id="nn::sm::detail::IUserInterface(1)">
-							
-							
-							  <code class="signature">[1] <a href="#nn::sm::detail::IUserInterface(1)">Unknown1</a>(u64) -&gt; KObject</code>
-							
+							  <input type="checkbox" class="showDocs" id="showDocs(nn::sm::detail::IUserInterface(1))"></input>
+							  <label for="showDocs(nn::sm::detail::IUserInterface(1))" class="showDocsLabel"></label>
+							  <code class="signature">[1] <a href="#nn::sm::detail::IUserInterface(1)">GetService</a>(<a href="types.html#ServiceName">ServiceName</a> name) -&gt; IPipe</code>
+							  <div class="docs"><p>Returns a handle to the given service. IPC messages may be sent to this
+							handle through <code>svcSendSyncRequest</code>.</p>
+							</div>
 							</li>
 							<li class="command" value="2" id="nn::sm::detail::IUserInterface(2)">
-							
-							
-							  <code class="signature">[2] <a href="#nn::sm::detail::IUserInterface(2)">Unknown2</a>(u64, u8, u32) -&gt; KObject</code>
-							
+							  <input type="checkbox" class="showDocs" id="showDocs(nn::sm::detail::IUserInterface(2))"></input>
+							  <label for="showDocs(nn::sm::detail::IUserInterface(2))" class="showDocsLabel"></label>
+							  <code class="signature">[2] <a href="#nn::sm::detail::IUserInterface(2)">RegisterService</a>(<a href="types.html#ServiceName">ServiceName</a> name, u8, u32 maxHandles) -&gt; NPort</code>
+							  <div class="docs"><p>Registers a service with the given name. The user can use
+							<code>svcAcceptSession</code> on the returned handle to get a new Session handle, and
+							use <code>svcReplyAndReceive</code> on those handles to reply to IPC requests.</p>
+							</div>
 							</li>
 							<li class="command" value="3" id="nn::sm::detail::IUserInterface(3)">
-							
-							
-							  <code class="signature">[3] <a href="#nn::sm::detail::IUserInterface(3)">Unknown3</a>(u64)</code>
-							
+							  <input type="checkbox" class="showDocs" id="showDocs(nn::sm::detail::IUserInterface(3))"></input>
+							  <label for="showDocs(nn::sm::detail::IUserInterface(3))" class="showDocsLabel"></label>
+							  <code class="signature">[3] <a href="#nn::sm::detail::IUserInterface(3)">UnregisterService</a>(<a href="types.html#ServiceName">ServiceName</a> name)</code>
+							  <div class="docs"><p>Unregisters the given service. Future <code>GetService</code> call will not return
+							this service anymore, but existing handles will stay alive.</p>
+							</div>
 							</li>
 						</ol>
 					</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -509,7 +509,7 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::socket::resolver::IResolver">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>
 						sfdnsres</a>
-						<a class="list-group-item list-group-item-action" href="ifaces.html#SmService">
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::sm::detail::IUserInterface">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="122" aria-valuemin="0" aria-valuemax="100" style="width: 122%"></div></div>
 						sm:</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::sm::detail::IManagerInterface">
@@ -594,9 +594,6 @@
 					<br />
 					<h2 id="interfaces">Interfaces</h2>
 					<div class="list-group">
-						<a class="list-group-item list-group-item-action" href="ifaces.html#SmService">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="166" aria-valuemin="0" aria-valuemax="100" style="width: 166%"></div></div>
-						SmService</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::account::IAccountServiceForAdministrator">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="66" aria-valuemin="0" aria-valuemax="100" style="width: 66%"></div></div>
 						nn::account::IAccountServiceForAdministrator</a>
@@ -1375,7 +1372,7 @@
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>
 						nn::sm::detail::IManagerInterface</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::sm::detail::IUserInterface">
-						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="166" aria-valuemin="0" aria-valuemax="100" style="width: 166%"></div></div>
 						nn::sm::detail::IUserInterface</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::socket::resolver::IResolver">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,6 +167,9 @@
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::spl::detail::IRandomInterface">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div></div>
 						csrng</a>
+						<a class="list-group-item list-group-item-action" href="ifaces.html#nns::hosbinder::IHOSBinderDriver">
+						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="66" aria-valuemin="0" aria-valuemax="100" style="width: 66%"></div></div>
+						dispdrv</a>
 						<a class="list-group-item list-group-item-action" href="ifaces.html#nn::erpt::sf::IContext">
 						<div class="progress" style="width: 100px"><div class="progress-bar bg-success progress-bar-striped" role="progressbar" aria-valuenow="16" aria-valuemin="0" aria-valuemax="100" style="width: 16%"></div></div>
 						erpt:c</a>

--- a/ipcdefs/auto.id
+++ b/ipcdefs/auto.id
@@ -4209,7 +4209,7 @@ interface nn::xcd::detail::ISystemServer is xcd:sys {
 	[102] Unknown102() -> u64;
 }
 
-interface nns::hosbinder::IHOSBinderDriver {
+interface nns::hosbinder::IHOSBinderDriver is dispdrv {
 	[0] TransactParcel(i32, u32, u32, buffer<unknown, 5, 0>) -> buffer<unknown, 6, 0>;
 	[1] AdjustRefcount(i32, i32, i32);
 	[2] GetNativeHandle(i32, u32) -> KObject;

--- a/ipcdefs/auto.id
+++ b/ipcdefs/auto.id
@@ -3309,7 +3309,7 @@ interface nn::pm::detail::IInformationInterface is pm:info {
 	[0] Unknown0(u64) -> u64;
 }
 
-interface nn::pm::detail::IShellInterface is pm:shel {
+interface nn::pm::detail::IShellInterface is pm:shell {
 	[0] Unknown0();
 	[1] Unknown1(u64);
 	[2] Unknown2(u64);

--- a/ipcdefs/sm.id
+++ b/ipcdefs/sm.id
@@ -1,6 +1,6 @@
 type ServiceName = bytes<8>;
 
-interface SmService is sm: {
+interface nn::sm::detail::IUserInterface is sm: {
 	# Needs to be called before any other command may be used. On version 3.0.0
 	# and lower, if this function is not called, `GetService`, `RegisterService`
 	# and `UnregisterService` may be called without restriction, thanks to

--- a/scripts/genallipc.py
+++ b/scripts/genallipc.py
@@ -8712,6 +8712,9 @@ smapping = {
 		'fgm':     'nn::fgm::sf::ISession',
 		'fgm:9':   'nn::fgm::sf::ISession', # no nn::fgm::sf::IDebugger ?
 	},
+	'010000000000001C': {  # nvnflinger
+		'dispdrv': 'nns::hosbinder::IHOSBinderDriver',
+	},
 	'010000000000001D': {  # pcie.withoutHb
 		'pcie': 'nn::pcie::detail::IManager',
 	},


### PR DESCRIPTION
I forgot to run it last time. No need to regenerate docs since pm:shell is manually handled by https://github.com/reswitched/SwIPC/blob/master/ipcdefs/pm.id

While I'm at it, I fixed the interface name in sm.id