### PR TITLE
Fix CommonMark usage due to breaking change in latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tatsu
-commonmark
+tatsu ~= 4.2.6
+commonmark ~= 0.8.1

--- a/scripts/gendocs.py
+++ b/scripts/gendocs.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('.')
 import idparser
-import CommonMark
+import commonmark
 
 class Multifile(object):
 	def __init__(self, *backing):
@@ -285,7 +285,7 @@ for name, iface in sorted(ifaces.items(), key=lambda x: x[0]):
 
 	if len(iface['doc']):
 		print >>nfp, '<li class="list-group-item">'
-		print >>nfp, '\t<div class="docs">%s</div>' % CommonMark.commonmark(iface['doc'])
+		print >>nfp, '\t<div class="docs">%s</div>' % commonmark.commonmark(iface['doc'])
 		print >>nfp, '</li>'
 	if len(iface['cmds']):
 		print >>nfp, '<li class="list-group-item">'
@@ -309,7 +309,7 @@ for name, iface in sorted(ifaces.items(), key=lambda x: x[0]):
 				else:
 					extra += "%s-%s" % (cmd['versionAdded'], cmd['lastVersion'])
 			print >>nfp,  '  <code class="signature">[%i%s] %s</code>' % (cmd['cmdId'], extra, cdef)
-			print >>nfp, ('  <div class="docs">%s</div>' % CommonMark.commonmark(cmd['doc']).encode('utf-8')) if cmd['doc'] != "" else ""
+			print >>nfp, ('  <div class="docs">%s</div>' % commonmark.commonmark(cmd['doc']).encode('utf-8')) if cmd['doc'] != "" else ""
 			print >>nfp,  '</li>'
 		nfp -= 2
 		print >>nfp, '\t</ol>'


### PR DESCRIPTION
CommonMark changed the module name in the lastest version from `CommonMark` to `commonmark` (https://github.com/rtfd/CommonMark-py/issues/137)
This broke build on TravisCI and new installations of the project.